### PR TITLE
Prevent unsupported pagination of Github API

### DIFF
--- a/releng/org.palladiosimulator.bench.oomph.generator/generateProjects.groovy
+++ b/releng/org.palladiosimulator.bench.oomph.generator/generateProjects.groovy
@@ -11,8 +11,8 @@ def templateFolderName
 def githubAuthToken*/
 
 def projects = fetch("https://api.github.com/orgs/PalladioSimulator/repos?per_page=100").name.unique(false).collect{it.toString()}.sort()
-def projectSetupFiles = fetch("https://api.github.com/search/code?q=extension:setup+org:PalladioSimulator+path:releng").items
-def projectTargetPlatforms = fetch("https://api.github.com/search/code?q=extension:target+org:PalladioSimulator+path:releng").items
+def projectSetupFiles = fetch("https://api.github.com/search/code?q=extension:setup+org:PalladioSimulator+path:releng?per_page=100").items
+def projectTargetPlatforms = fetch("https://api.github.com/search/code?q=extension:target+org:PalladioSimulator+path:releng?per_page=100").items
 def projectsWithoutSetupFile = projects - projectSetupFiles.repository.name.unique(false).collect{it.toString()}.sort()
 
 def projectGenerator = new ProjectGenerator(outputFolderName: "$outputFolderName/projects", templateFolder: new File(templateFolderName))


### PR DESCRIPTION
For larger api results Github uses pagination by default. This is currently not supported by our script. Hence, we need to increase the result set size to the allowed maximum of 100.